### PR TITLE
fix: data-include-format

### DIFF
--- a/docs/visi1.6/index.html
+++ b/docs/visi1.6/index.html
@@ -26,21 +26,21 @@
   <!--Dit document is in bewerking-->
   </section>
 <!-- hoofdstuk 1 -->
-<section data-format="markdown" data-include="summary.md"></section>  
+<section data-include-format="markdown" data-include="summary.md"></section>  
 <!-- hoofdstuk 2 -->
-<section data-format="markdown" data-include="introduction.md"></section>
+<section data-include-format="markdown" data-include="introduction.md"></section>
 <!-- hoofdstuk 3 -->
-<section data-format="markdown" data-include="conceptual.md"></section>
+<section data-include-format="markdown" data-include="conceptual.md"></section>
 <!-- hoofdstuk 4 -->
-<section data-format="markdown" data-include="functional-1.md"></section>
+<section data-include-format="markdown" data-include="functional-1.md"></section>
 <!-- hoofdstuk 5 -->
-<section data-format="markdown" data-include="functional-2.md"></section>
+<section data-include-format="markdown" data-include="functional-2.md"></section>
 <!-- hoofdstuk 6 -->
-<section data-format="markdown" data-include="technical.md"></section>
+<section data-include-format="markdown" data-include="technical.md"></section>
 <!-- hoofdstuk 7 -->
-<section data-format="markdown" data-include="soap.md"></section>
+<section data-include-format="markdown" data-include="soap.md"></section>
 <!-- hoofdstuk 8 -->
-<section data-format="markdown" data-include="testprotocol.md"></section>
+<section data-include-format="markdown" data-include="testprotocol.md"></section>
   
 <section id='conformance'>
     <!-- This section is filled automatically by ReSpec. -->


### PR DESCRIPTION
Deze PR corrigeert de wijze waarop de hoofdstukken ingeladen worden. 
Dit komt voort uit een functionele wijziging van w3c/respec, waarbij `[data-format="markdown"]` eerst wel werkte bij `[data-include]`. 

A.B. schreef: 

> tot voor kort was de inhoudsopgave erg inzichtelijk omdat je naar alle paragrafen kon klikken.
>
> Sinds de respec software update van 5 april zijn alle paragraafnummers verdwenen en worden de paragrafen niet meer in de inhoudsopgave getoond.

